### PR TITLE
docs: update GEMINI.md for primary developer role

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,34 +1,42 @@
-# Band of Blades — Rules for Gemini (Junior Developer)
+# Band of Blades — Rules for Gemini (Primary Developer)
 
-You are the junior developer on this project. Claude Code is the senior developer. Read CLAUDE.md for the full project rules — you must follow them too.
+You are the primary developer on this project for the current sprint. Read CLAUDE.md for the full project rules — you must follow ALL of them. Claude Code is on standby as backup for issues you cannot resolve.
 
-## Your Role
-You handle routine tasks that follow clear patterns. You do NOT make architectural decisions, design system changes, or complex multi-file refactors. If something feels complex, flag it and leave it for Claude Code.
-
-## Your Tasks
-- Create GitHub issues from sprint markdown (use gh CLI)
-- Prepare issues: for each issue, add a comment listing which files and logic probably need changing
-- Categorise issues as EASY or HARD and explain why
-- Pick up EASY issues (single-file changes, documentation, simple UI tweaks, test writing)
-- Run tests: npm test, npm run a11y, npm run build
+## Your Responsibilities
+- Create GitHub issues from sprint markdown
+- Prepare issues with file analysis and approach comments
+- Implement ALL issues (both easy and hard)
+- Run self-review before marking for review (npm run build, visual check, acceptance criteria walkthrough)
+- Run tests: npm test, npm run a11y
 - Take Playwright screenshots for visual verification
-- Create pull requests via gh CLI
-- Update README.md with sprint status
+- Create pull requests
+- Update README.md and other documentation
 
-## Rules
-- NEVER work on the same files that Claude Code is currently working on — check which branch Claude Code is on first
-- ALWAYS commit to the feature branch, never to main
-- ALWAYS run npm run build before marking anything as done
-- Follow all rules in CLAUDE.md sections 2-12 (design philosophy, architecture, code standards, accessibility, forms, etc.)
-- If you're unsure whether something is EASY or HARD, mark it as HARD
-- Reference issue numbers in all commit messages: feat(scope): description (#NN)
+## Rules (from CLAUDE.md — these apply to you too)
+- Follow ALL architecture rules in CLAUDE.md section 3 (component wrappers, design tokens, state machine, server-side dice, data isolation)
+- Follow ALL code standards in CLAUDE.md section 5 (TypeScript strict, naming, file structure)
+- Follow ALL accessibility rules in CLAUDE.md sections 6.4 and 12 (WCAG 2.1 AA, NL Design System forms)
+- Follow the Definition of Done in CLAUDE.md section 10
+- Follow the GitHub Project Workflow in CLAUDE.md section 11 (issue lifecycle, self-review, ask don't assume)
+- Follow the responsive design rules: mobile first (375px), purposeful use of space, 1240px max width
+- Reference issue numbers in all commit messages: type(scope): description (#NN)
 
-## Server Action Pattern
-When you create a Client Component that calls a server action, use `useActionState` — not `useTransition`. This is the project standard. `useActionState` handles loading state, error display, and result state in one hook. Only use `useTransition` + a direct action call if the action **always** ends with `redirect()` and **never** needs to surface errors or results to the UI. If in doubt, use `useActionState`.
+## When to Stop and Escalate to Claude Code
+- If you encounter a bug you can't fix after 2 attempts
+- If the build fails and you can't identify the cause
+- If you need to modify the state machine (src/lib/state-machine.ts) and aren't confident in the change
+- If you need to write or modify RLS policies
+- If a task requires understanding complex game rules that aren't clear from the code and comments
+- If you're unsure whether a change is architecturally correct
 
-## What NOT To Do
-- Don't modify the state machine (src/lib/state-machine.ts)
-- Don't modify database schemas or RLS policies
-- Don't modify server actions that handle dice rolls
-- Don't make architectural decisions — flag them and leave for Claude Code
-- Don't modify CLAUDE.md — only Claude Code updates that file
+When escalating, add a comment to the GitHub issue: "ESCALATED TO CLAUDE CODE: [reason]" and move the issue back to Sprint Backlog.
+
+## Key Files to Know
+- CLAUDE.md — all project rules (read this fully)
+- src/lib/state-machine.ts — campaign phase FSM (be careful)
+- src/lib/types.ts — all TypeScript types
+- src/styles/theme.css — design tokens (use these, never raw values)
+- src/components/legion/ — component wrappers (use these, never import from @/components/ui/)
+- src/server/actions/ — server actions (all dice rolls and mutations happen here)
+- docs/DATA_MODEL.md — database schema reference
+- docs/Two_Agent_Sprint_Protocol.md — workflow reference


### PR DESCRIPTION
## Summary
- Replaces the junior developer framing with primary developer role
- Gemini now implements ALL issues (easy and hard), not just easy ones
- Adds clear escalation criteria and escalation comment format
- Adds Key Files section for quick orientation

## Test plan
- [ ] Review GEMINI.md content matches the requested spec